### PR TITLE
Added support for specifiying a complete GUID for a message

### DIFF
--- a/GroupMeClientApi/Models/Message.cs
+++ b/GroupMeClientApi/Models/Message.cs
@@ -167,12 +167,15 @@ namespace GroupMeClientApi.Models
         /// <param name="body">The message contents.</param>
         /// <param name="attachments">A list of attachments to be included with the message.</param>
         /// <param name="guidPrefix">An optional prefix to add to the message's GUID.</param>
+        /// <param name="guid">The GUID to use for the message. If null or blank, a random GUID will be generated. Any applicable prefixes will be included.</param>
         /// <returns>True if successful, false otherwise.</returns>
-        public static Message CreateMessage(string body, IEnumerable<Attachments.Attachment> attachments = null, string guidPrefix = "")
+        public static Message CreateMessage(string body, IEnumerable<Attachments.Attachment> attachments = null, string guidPrefix = "", string guid = "")
         {
+            guid = string.IsNullOrEmpty(guid) ? Guid.NewGuid().ToString() : guid;
+
             var msg = new Message()
             {
-                SourceGuid = $"{guidPrefix}-{Guid.NewGuid().ToString()}",
+                SourceGuid = $"{guidPrefix}-{guid}",
                 Text = body,
                 Attachments = new List<Attachments.Attachment>(attachments ?? Enumerable.Empty<Attachments.Attachment>()),
                 FavoritedBy = new List<string>(),


### PR DESCRIPTION
A complete message guid can be specified in the Message.CreateMessage function