### PR TITLE
Update JSONSubTypes and Newtonsoft Json

### DIFF
--- a/GroupMeClientApi/GroupMeClientApi.csproj
+++ b/GroupMeClientApi/GroupMeClientApi.csproj
@@ -44,8 +44,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JsonSubTypes" Version="1.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="JsonSubTypes" Version="1.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Update 
- JSONSubTypes to v1.8.0
- Newtonsoft Json to v13.0.1