### PR TITLE
Add link to docs in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 Find [GroupMeClientApi](https://www.nuget.org/packages/GroupMeClientApi/) on NuGet.
 
+Find [Documentation Here](https://alexdillon.github.io/GroupMeClientApi/).
 ### Sample
 ```csharp
 var client = new GroupMeClientApi.GroupMeClient("YOUR_API_TOKEN HERE");


### PR DESCRIPTION
This PR adds a link to the documentation to the README.md file, making it easier for future users to find the docs.

I had already made a PR for this earlier, but closed it as I had accidentally contaminated it.